### PR TITLE
Replaced bugzilla stats method call with cached version.

### DIFF
--- a/themes/QMO4/members/single/metrics.php
+++ b/themes/QMO4/members/single/metrics.php
@@ -27,7 +27,7 @@
         $user_email = $user->user_email;
         $bz_settings = get_option('bzstats_settings');
         
-        try {  $stats = get_bugzilla_stats_for_email($user->user_email);  } 
+        try {  $stats = get_bugzilla_stats_for_user($user);  } 
         catch (Exception $e) {  }
       ?>
 


### PR DESCRIPTION
get_bugzilla_stats_for_email is the non-cached method for grabbing bugzilla stats. get_bugzilla_stats_for_user includes WP user information so it can cache the data in the user-meta database table.
