### PR TITLE
[fix bug 998219] Privacy policy url fixed

### DIFF
--- a/themes/QMO4/footer.php
+++ b/themes/QMO4/footer.php
@@ -4,7 +4,7 @@
 <?php do_action( 'bp_before_footer' ); ?>
     
   <footer id="site-info" role="contentinfo" class="section">
-    <p id="copyright">Copyright &copy; <?php echo date('Y'); ?> Mozilla. All rights reserved. | <a href="http://www.mozilla.org/privacy-policy.html" rel="external">Privacy Policy</a> | <a href="http://www.mozilla.org/about/legal.html" rel="external">Legal Notices</a></p>
+    <p id="copyright">Copyright &copy; <?php echo date('Y'); ?> Mozilla. All rights reserved. | <a href="http://www.mozilla.org/privacy/websites/" rel="external">Privacy Policy</a> | <a href="http://www.mozilla.org/about/legal.html" rel="external">Legal Notices</a></p>
     <p>Portions of QMO content are &copy; 1998&ndash;<?php echo date('Y');?> by individual mozilla.org contributors.</p>
     <p>Some content available under a <a href="http://www.mozilla.org/foundation/licensing/website-content.html" rel="external license">Creative Commons license</a></p>
     <p><a href="https://github.com/mozilla/quality.mozilla.org" rel="external">Our code is on Github</a></p>

--- a/themes/QMO5/footer.php
+++ b/themes/QMO5/footer.php
@@ -1,7 +1,7 @@
     </div><!-- /#content -->
 
   <footer id="site-info" role="contentinfo" class="section">
-    <p id="copyright">Copyright &copy; <?php echo date('Y'); ?> Mozilla. All rights reserved. | <a href="http://www.mozilla.org/privacy-policy.html" rel="external">Privacy Policy</a> | <a href="http://www.mozilla.org/about/legal.html" rel="external">Legal Notices</a></p>
+    <p id="copyright">Copyright &copy; <?php echo date('Y'); ?> Mozilla. All rights reserved. | <a href="http://www.mozilla.org/privacy/websites/" rel="external">Privacy Policy</a> | <a href="http://www.mozilla.org/about/legal.html" rel="external">Legal Notices</a></p>
     <p>Portions of QMO content are &copy; 1998&ndash;<?php echo date('Y');?> by individual mozilla.org contributors.</p>
     <p>Some content available under a <a href="http://www.mozilla.org/foundation/licensing/website-content.html" rel="external license">Creative Commons license</a></p>
     <p><a href="https://github.com/mozilla/quality.mozilla.org" rel="external">Our code is on Github</a></p>


### PR DESCRIPTION
The url for the privacy policy has changed from http://www.mozilla.org/privacy-policy.html to http://www.mozilla.org/privacy/websites/

We should update the /about/ page to reflect this.
